### PR TITLE
SIPX-825 Fix CFEngine promises

### DIFF
--- a/sipXsupervisor/etc/cfengine_stdlib.cf
+++ b/sipXsupervisor/etc/cfengine_stdlib.cf
@@ -221,7 +221,7 @@ field_edits:
 
 insert_lines:
 
-  "$(index)=$($(v)[$(index)])",
+  "$(index)=$($(v)[$(index)])"
 
          comment => "Insert a variable definition",
       ifvarclass => "!$(cindex[$(index)])_in_file";
@@ -245,7 +245,7 @@ classes:
 
 insert_lines:
 
-  "$($(v)[$(index)])",
+  "$($(v)[$(index)])"
 
          comment => "Append users into a password file format",
       ifvarclass => "add_$(index)";
@@ -269,7 +269,7 @@ classes:
 
 insert_lines:
 
-  "$($(v)[$(index)])",
+  "$($(v)[$(index)])"
 
          comment => "Append users into a group file format",
       ifvarclass => "add_$(index)";


### PR DESCRIPTION
The policy file parser is stricter in CFEngine >=3.5.0. The parser is now fully compliant with the CFEngine language syntax reference. The main difference you will encounter is that promiser/promisee no longer allows a comma at the end of the line